### PR TITLE
v1.2.2

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -16,20 +16,39 @@
 			"tip": "Do it on a empty canvas to increase performance. You can also put some websites that allow iframes."
 		},
 		"minUI": {
-			"name": "Minimal UI",
+			"name": "Minimal User Interface",
 			"desc": "Removes unnecessary FoundryVTT's UI elements while a HTML file is being displayed."
 		},
 		"keepTop": {
 			"name": "Keep Scene Changer",
 			"desc": "Maintains the Scene Changer at the top of the screen in any case."
 		},
+		"keepPlayerList": {
+			"name": "Keep Player List",
+			"desc": "Maintains the player list in its original position."
+		},
+		"keepBottomControls": {
+			"name": "Keep Bottom Controls",
+			"values": {
+				"defaultnone": "Hide all controls",
+				"macrobaronly": "Allow the hotbar",
+				"camerasonly": "Allow the cameras",
+				"both": "Allow the hotbar and the cameras",
+				"macroplusfps": "Allow the hotbar and the FPS meter",
+				"cameraplusfps": "Allow the cameras and the FPS meter",
+				"bothplusfps": "Allow the hotbar, the cameras and the FPS meter",
+				"fpsonly": "Allow only FoundryVTT's FPS meter"
+			},
+			"desc": "Allows you to select how do you want the bottom controls be displayed.",
+			"tip": "You can use \"Allow the cameras and the FPS meter\" while you don't use any cameras to change the FPS meter location."
+		},
 		"spaceRight": {
-			"name": "Respect sidebar's space",
+			"name": "Respect Sidebar's Space",
 			"desc": "Adds an empty space under the sidebar.",
 			"tip": "You can change the color of the canvas' background color to affect the color behind the controls."
 		},
 		"rightDisabled": {
-			"name": "Disable sidebar",
+			"name": "Disable Sidebar",
 			"desc": "Removes the sidebar from the UI, enabling back the scene changer on the top. (Ideal if your group communicates via voice chat or doesn't need to throw dice).",
 			"tip": "You might want to have other scene visible to gain back normal FoundryVTT's controls. (If not, you can always disable this module for the current scene)."
 		},
@@ -42,27 +61,40 @@
 			"desc": "Hides SmallTime's clock (if active)."
 		},
 		"hideBoard": {
-			"name": "Hide FoundryVTT's board",
-			"desc": "Hides the board for a noticeable performace boost. (You won't render the canvas).",
+			"name": "Hide FoundryVTT's Board",
+			"desc": "Hides the board for a noticeable performace boost. (You WILL NOT render the canvas).",
 			"tip": "Other modules that may depend on the board might malfunction or do nothing, check your browser's console."
 		},
 		"passData": {
-			"name": "Enable helpers for two-way communication",
+			"name": "Enable Helpers For Two-Way Communication",
 			"desc": "Puts in use inactive variables to help to make two way communication between the iframe and FoundryVTT easier. See the wiki on GitHub for a better explanation.",
 			"tip": "To fully make use of this you will need to have coding and macro knowledge."
 		},
 		"dataUpdateRate": {
-			"name": "FoundryVTTAccess update rate",
+			"name": "FoundryVTTAccess Update Rate",
 			"values": {
-				"default": "Don't update. Refresh to update.",
-				"fivesec": "One update every 5 seconds.",
-				"onesec": "One update each second.",
-				"halfasec": "Two updates per second.",
-				"cuarterofasec": "Four updates per second.",
-				"realtime":	"Real-time."
+				"default": "Don't update. Refresh to update",
+				"fivesec": "One update every 5 seconds",
+				"onesec": "One update each second",
+				"halfsec": "Two updates per second",
+				"cuarterofasec": "Four updates per second",
+				"realtime":	"Real-time"
 			},
 			"desc": "Changes the speed that the variable FoundryVTTAccess updates with new information. Use updateRate to sync it with your iframe.",
 			"tip": "This could affect performace. Depends on the use."
+		},
+		"iFrameRefreshRate": {
+			"name": "IFrame Refreshing",
+			"values": {
+				"defaultnone": "It WILL NOT forcefully updated",
+				"oneminute": "It will be forcefully updated once every minute",
+				"thirtyseconds": "It will be forcefully updated once every thirty seconds",
+				"fifteenseconds": "It will be forcefully updated once every fifteen seconds",
+				"tenseconds": "It will be forcefully updated once every ten seconds",
+				"fiveseconds":	"It will be forcefully updated once every five seconds"
+			},
+			"desc": "Changes the speed that the IFrame is forcefully refreshed.",
+			"tip": "This feature is intended to provide a way to reload the Iframe without having to reload FoundryVTT. You shouldn't use this as a way to refresh information from it, as it will attempt the reload to all players, having to serve everything again."
 		},
 		"rememberjsexecution": "Please, remember to input only files that you fully trust. You might be allowing unwanted javascript execution in your system. And that is bad."
 	}

--- a/lang/es.json
+++ b/lang/es.json
@@ -11,25 +11,44 @@
 			"desc": "Activa HTML A Escena en esta escena."
 		},
 		"fileLoc": {
-			"name": "Selecciona un fichero HTML",
+			"name": "Selecciona Un Fichero HTML",
 			"hint": "Puedes seleccionar cualquier fichero HTML almacenado en la carpeta data de tu FoundryVTT.",
 			"tip": "Hazlo en una escena en blanco para aumentar el rendimiento. También puedes introducir algunas páginas web que permitan iframes"
 		},
 		"minUI": {
-			"name": "Interfaz mínima",
+			"name": "Interfaz Mínima",
 			"desc": "Elimina elementos innecesarios de la interfaz de FoundryVTT mientras un fichero HTML está siendo mostrado."
 		},
 		"keepTop": {
-			"name": "Mantener el cambiador de escenas",
+			"name": "Mantener El Cambiador De Jscenas",
 			"desc": "Mantiene el cambiador de escenas en la parte superior de la pantalla en cualquier caso."
 		},
+		"keepPlayerList": {
+			"name": "Mantener La Lista De Jugadores",
+			"desc": "Mantiene la lista de jugadores en su posición original."
+		},
+		"keepBottomControls": {
+			"name": "Mantener Los Controles Inferiores",
+			"values": {
+				"defaultnone": "Esconde todos los controles",
+				"macrobaronly": "Permite la barra de acceso rápido",
+				"camerasonly": "Permite las cámaras",
+				"both": "Permite la barra de acceso rápido y las cámaras",
+				"macroplusfps": "Permite la barra de acceso rápido y el indicador de fotogramas por segundo",
+				"cameraplusfps": "Permite las cámaras y el indicador de fotogramas por segundo",
+				"bothplusfps": "Permite la barra de acceso rápido, las cámaras y el indicador de fotogramas por segundo",
+				"fpsonly": "Permite únicamente el indicador de fotogramas por segundo de FoundryVTT"
+			},
+			"desc": "Te permite seleccionar como quieres que los controles inferiores sean mostrados.",
+			"tip": "Puedes usar \"Permite las cámaras y el indicador de fotogramas por segundo\" mientras no estas usando ninguna cámara para cambiar la posición del indicador de fotogramas por segundo."
+		},
 		"spaceRight": {
-			"name": "Respeta el espacio de la barra lateral",
+			"name": "Respeta El Espacio De La Barra Lateral",
 			"desc": "Añade un espacio en blanco bajo la barra lateral.",
 			"tip": "Puedes cambiar el color del fondo de la escena para cambiar el color que se muestra bajo los controles."
 		},
 		"rightDisabled": {
-			"name": "Desactiva la barra lateral",
+			"name": "Desactiva La Barra Lateral",
 			"desc": "Elimina la barra lateral, reactivando el intercambiador de escenas en la parte superior. (Ideal si tu grupo se comunica por chat de voz o no necesita lanzar dados).",
 			"tip": "Posiblemente quedrás tener otra escena visible para ganar de vuelta los controles normales de FoundryVTT. (Si no, siempre puedes desactivar el modulo para la escena actual)."
 		},
@@ -42,27 +61,40 @@
 			"desc": "Esconde el reloj de SmallTime (en el acaso de estar activado)."
 		},
 		"hideBoard": {
-			"name": "Esconde el tablero de FoundryVTT",
-			"desc": "Esconde el tablero por un aumento de rendimiento palpable. (No renderizarás el canvas).",
+			"name": "Esconde El Tablero De FoundryVTT",
+			"desc": "Esconde el tablero por un aumento de rendimiento palpable. (NO renderizarás el canvas).",
 			"tip": "Otros modulos que usen el tablero pueden empezar a malfuncionar o hacer nada, comprueba la consola de tu navegador."
 		},
 		"passData": {
-			"name": "Activa ayudas para la intercomunicación",
+			"name": "Activa Ayudas Para La Intercomunicación",
 			"desc": "Pone en uso variables inactivas para ayudar a realizar la intercomunicación entre el iframe y FoundryVTT. Ver la wiki de GitHub para una mejor explicación (Inglés).",
 			"tip": "Para dar uso completo a esto, tendrás que tener conocimientos de programación y de macros."
 		},
 		"dataUpdateRate": {
-			"name": "Tasa de actualización de FoundryVTTAccess",
+			"name": "Tasa De Actualización De FoundryVTTAccess",
 			"values": {
-				"default": "No se actualiza. Refrescar para actualizar.",
-				"fivesec": "Una actualización cada 5 segundos.",
-				"onesec": "Una actualización cada segundo.",
-				"halfasec": "Dos actualizaciones por segundo.",
-				"cuarterofasec": "Cuatro actualizaciones por segundo.",
-				"realtime":	"Tiempo real."
+				"default": "No se actualiza. Refrescar para actualizar",
+				"fivesec": "Una actualización cada 5 segundos",
+				"onesec": "Una actualización cada segundo",
+				"halfsec": "Dos actualizaciones por segundo",
+				"cuarterofasec": "Cuatro actualizaciones por segundo",
+				"realtime":	"Tiempo real"
 			},
 			"desc": "Cambia la velocidad en la que la variable FoundryVTTAccess se actualiza con información nueva. Utiliza updateRate para sincronizarla con tu iframe.",
 			"tip": "This could affect performace. Depends on the use."
+		},
+		"iFrameRefreshRate": {
+			"name": "Actualización de IFrame",
+			"values": {
+				"defaultnone": "NO será forzadamente actualizado",
+				"oneminute": "Será forzadamente actualizado cada minuto",
+				"thirtyseconds": "Será forzadamente actualizado cada treinta segundos",
+				"fifteenseconds": "Será forzadamente actualizado cada quince segundos",
+				"tenseconds": "Será forzadamente actualizado cada diez segundos",
+				"fiveseconds":	"Será forzadamente actualizado cada cinco segundos"
+			},
+			"desc": "Cambia la velocidad en la que el IFrame es forzadamente actualizado",
+			"tip": "Esta característica está pensada para proporcionar una forma de recargar el IFrame sin tener que recargar FoundryVTT. No debes usar esto como una forma de refrescar la información del mismo, ya que forzará la recarga a todos los jugadores, teniendo que servir todo de nuevo."
 		},
 		"rememberjsexecution": "Por favor, recuerde de introducir solo ficheros en los que confie plenamente. Puedes estar permitiendo ejecución de javascript no solicitado en tu sistema. Y eso es malo."
 	}

--- a/module.json
+++ b/module.json
@@ -15,14 +15,16 @@
 	"bugs": "https://github.com/Javiondox/html-to-scene/issues",
 	"changelog": "https://github.com/Javiondox/html-to-scene/releases",
 	"flags": {},
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"minimumCoreVersion": "9",
 	"compatibleCoreVersion": "9",
 	"scripts": [
 		"scripts/core.js"
 	],
 	"esmodules": [],
-	"styles": [],
+	"styles": [
+		"css/styleclasses.css"
+	],
 	"languages": [
 		{
 			"lang": "en",

--- a/templates/sceneSettings.html
+++ b/templates/sceneSettings.html
@@ -21,13 +21,43 @@
 	<hr>
 	<div class="form-group">
 		<label>{{ localize "htmltoscene.minUI.name" }}</label>
-		<input type="checkbox" name="flags.htmltoscene.minUI" data-dtype="Boolean" {{#if minUI}} checked{{/if}}>
+		<input type="checkbox" name="flags.htmltoscene.minUI" data-dtype="Boolean" {{#if minUI}} checked{{/if}} onclick="syncMinUI(this)">
 		<p class="notes">{{ localize "htmltoscene.minUI.desc" }}</p>
 	</div>
 	<div class="form-group">
 		<label>{{ localize "htmltoscene.keepTop.name" }}</label>
-		<input type="checkbox" name="flags.htmltoscene.keepTop" data-dtype="Boolean" {{#if keepTop}} checked{{/if}}>
+		<input type="checkbox" class="htmltosceneMinUIOnly" name="flags.htmltoscene.keepTop" data-dtype="Boolean" {{#if keepTop}} checked{{/if}} {{#unless minUI}} disabled {{/unless}}>
 		<p class="notes">{{ localize "htmltoscene.keepTop.desc" }}</p>
+	</div>
+	<div class="form-group">
+		<label>{{ localize "htmltoscene.keepPlayerList.name" }}</label>
+		<input type="checkbox" class="htmltosceneMinUIOnly" name="flags.htmltoscene.keepPlayerList" data-dtype="Boolean" {{#if keepPlayerList}} checked{{/if}} {{#unless minUI}} disabled {{/unless}}>
+		<p class="notes">{{ localize "htmltoscene.keepPlayerList.desc" }}</p>
+	</div>
+	<div class="form-group">
+		<label>{{ localize "htmltoscene.keepBottomControls.name" }}</label>
+		<select name="flags.htmltoscene.keepBottomControls"  class="htmltosceneMinUIOnly" data-dtype="Number" {{#unless minUI}} disabled {{/unless}}>
+			{{#select flags.htmltoscene.keepBottomControls}}
+			<option value=0 {{#ifEquals keepBottomControls 0}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.keepBottomControls.values.defaultnone" }}</option>
+			<option value=1 {{#ifEquals keepBottomControls 1}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.keepBottomControls.values.macrobaronly" }}</option>
+			<option value=2 {{#ifEquals keepBottomControls 2}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.keepBottomControls.values.camerasonly" }}</option>
+			<option value=3 {{#ifEquals keepBottomControls 3}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.keepBottomControls.values.both" }}</option>
+			<option value=4 {{#ifEquals keepBottomControls 4}} selected{{/ifEquals}}>{{ localize
+					"htmltoscene.keepBottomControls.values.macroplusfps" }}</option>
+			<option value=5 {{#ifEquals keepBottomControls 5}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.keepBottomControls.values.cameraplusfps" }}</option>
+			<option value=6 {{#ifEquals keepBottomControls 6}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.keepBottomControls.values.bothplusfps" }}</option>
+			<option value=7 {{#ifEquals keepBottomControls 7}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.keepBottomControls.values.fpsonly" }}</option>
+			{{/select}}
+		</select>
+		<p class="notes">{{ localize "htmltoscene.keepBottomControls.desc" }}</p>
+		<p class="notes"><b>{{ localize "htmltoscene.recommendationtip" }}</b>{{ localize "htmltoscene.keepBottomControls.tip" }}
 	</div>
 	<div class="form-group">
 		<label>{{ localize "htmltoscene.spaceRight.name" }}</label>
@@ -87,7 +117,29 @@
 			<option value=5 {{#ifEquals dataUpdateRate 5}} selected{{/ifEquals}}>{{ localize "htmltoscene.dataUpdateRate.values.realtime" }}</option>
 			{{/select}}
 		</select>
+		<p class="notes">{{ localize "htmltoscene.dataUpdateRate.desc" }}</p>
 		<p class="notes"><b>{{ localize "htmltoscene.warningtip" }}</b>{{ localize "htmltoscene.dataUpdateRate.tip" }}
+	</div>
+	<div class="form-group">
+		<label>{{ localize "htmltoscene.iFrameRefreshRate.name" }}</label>
+		<select name="flags.htmltoscene.iFrameRefreshRate" data-dtype="Number">
+			{{#select flags.htmltoscene.iFrameRefreshRate}}
+			<option value=0 {{#ifEquals iFrameRefreshRate 0}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.iFrameRefreshRate.values.defaultnone" }}</option>
+			<option value=60000 {{#ifEquals iFrameRefreshRate 60000}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.iFrameRefreshRate.values.oneminute" }}</option>
+			<option value=30000 {{#ifEquals iFrameRefreshRate 30000}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.iFrameRefreshRate.values.thirtyseconds" }}</option>
+			<option value=15000 {{#ifEquals iFrameRefreshRate 15000}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.iFrameRefreshRate.values.fifteenseconds" }}</option>
+			<option value=10000 {{#ifEquals iFrameRefreshRate 10000}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.iFrameRefreshRate.values.tenseconds" }}</option>
+			<option value=5000 {{#ifEquals iFrameRefreshRate 5000}} selected{{/ifEquals}}>{{ localize
+				"htmltoscene.iFrameRefreshRate.values.fiveseconds" }}</option>
+			{{/select}}
+		</select>
+		<p class="notes">{{ localize "htmltoscene.iFrameRefreshRate.desc" }}</p>
+		<p class="notes"><b>{{ localize "htmltoscene.warningtip" }}</b>{{ localize "htmltoscene.iFrameRefreshRate.tip" }}
 	</div>
 	<p class="notes" style="font-style:italic;color:brown">{{ localize "htmltoscene.rememberjsexecution" }}</p>
 	<script>
@@ -99,5 +151,16 @@
 				syncTarget.disabled = true;
 			}
 		}
+		function syncMinUI(cb) {
+				syncTargets = document.getElementsByClassName("htmltosceneMinUIOnly")
+				console.log(syncTargets)
+				Array.prototype.forEach.call(syncTargets, function (syncTarget) {
+					if (cb.checked) {
+						syncTarget.disabled = false;
+					} else {
+						syncTarget.disabled = true;
+					}
+				})
+			}
 	</script>
 </div>


### PR DESCRIPTION
Added: Toggle for showing the player list.
Added: A drop-down to change how the controls at the bottom are shown (You can now show the macro bar, the camera and the fps over the iframe as you like)
Added: Forced IFrame refreshing to make the developing things inside FoundryVTT easier.

Changes: Made the settings menu more intuitive disabling some features (not all, because some can have some usage) that doesn't make any sense (Like forcing to keep the scene changer when you haven't enabled minimal user interface even).

Fixed: Non translated text on the FoundryVTTAccess Update Rate drop-down.
Fixed: Put back some translated strings that weren't on the template.
Fixed: Scene changer moving to the left in some occasions.
Fixed: Some typos and made the capitalization in the config more consistent with Foundry's default settings.